### PR TITLE
use Generics with a Codable protocol to allow custom data types

### DIFF
--- a/Classes/BatchApp.swift
+++ b/Classes/BatchApp.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct BatchApp: Codable {
+public struct DefaultBatchApp: Codable {
     public var buildNumber: String?
     public var appName: String?
     public var appVersion: String?

--- a/Classes/BatchElement.swift
+++ b/Classes/BatchElement.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public struct BatchElement: SegmentBatchCodable {
-    public var app: BatchApp?
-    public var traits: BatchTraits?
-    public var properties: BatchProperties?
+public struct DefaultBatchElement: SegmentBatchCodable {
+    public var app: DefaultBatchApp?
+    public var traits: DefaultBatchTraits?
+    public var properties: DefaultBatchProperties?
     public var type: String?
     public var name: String?
 }

--- a/Classes/BatchElement.swift
+++ b/Classes/BatchElement.swift
@@ -8,9 +8,10 @@
 
 import Foundation
 
-public struct BatchElement: Codable {
+public struct BatchElement: SegmentBatchCodable {
     public var app: BatchApp?
     public var traits: BatchTraits?
     public var properties: BatchProperties?
     public var type: String?
+    public var name: String?
 }

--- a/Classes/BatchProperties.swift
+++ b/Classes/BatchProperties.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct BatchProperties: Codable {
+public struct DefaultBatchProperties: Codable {
         public var pageName: String?
         public var appVersion: String?
         public var pushEnabled: Bool?

--- a/Classes/BatchTraits.swift
+++ b/Classes/BatchTraits.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public struct BatchTraits: Codable {
+public struct DefaultBatchTraits: Codable {
     public var mvpd: String?
 }

--- a/Classes/Segment.swift
+++ b/Classes/Segment.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public struct Segment: Codable {
-    public var batch: [BatchElement]?
+public struct Segment<T: SegmentBatchCodable>: Codable {
+    public var batch: [T]?
 }

--- a/Classes/SegmentBatchCodable.swift
+++ b/Classes/SegmentBatchCodable.swift
@@ -1,0 +1,13 @@
+//
+//  SegmentBatchCodable.swift
+//  ios-segment-tool
+//
+//  Created by Samuel Lambert on 4/29/20.
+//
+
+import Foundation
+
+public protocol SegmentBatchCodable: Codable {
+    var type: String? { get }
+    var name: String? { get }
+}

--- a/Classes/SegmentService.swift
+++ b/Classes/SegmentService.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+public typealias SegmentResult<T: SegmentBatchCodable> = Result<[T], Error>
+public typealias DefaultSegmentResult = SegmentResult<BatchElement>
+
 public enum SegmentError: Error {
     case noElementsFound
 }
@@ -20,14 +23,14 @@ public class SegmentService {
     }
     
     // Waits in 5 second intervals. Default numberOfTries waits 90 seconds.
-    public func checkForSegmentCalls(expectedCallType: String, expectedPageType: String, completion: @escaping (Result<[BatchElement], Error>) -> ()) {
+    public func checkForSegmentCalls<T: SegmentBatchCodable>(expectedCallType: String, expectedPageName: String, completion: @escaping (Result<[T], Error>) -> ()) {
         let client = CharlesClient()
         let service = SegmentService()
         client.exportData(completion: { (data) in
             service.dataToProxyLogIn(from: data!, completion: { (log) in
-                service.segmentCallsIn(from: log, completion: { (segmentList) in
+                service.segmentCallsIn(from: log, completion: { (segmentList: [Segment<T>]) in
                     service.matchingSegmentBatchesIn(
-                        completion: { (expectedBatchElements) in
+                        completion: { (expectedBatchElements: [T]) in
                             if expectedBatchElements.count > 0 {
                                 completion(.success(expectedBatchElements))
                             }
@@ -37,7 +40,7 @@ public class SegmentService {
                     },
                         from: segmentList,
                         expectedCallType: expectedCallType,
-                        expectedPageType: expectedPageType
+                        expectedPageName: expectedPageName
                     )
                 })
             })
@@ -49,25 +52,25 @@ public class SegmentService {
         completion(log)
     }
     
-    public func segmentCallsIn(from log: [ProxyLogElement], completion: @escaping ([Segment]) -> Void) {
-        var segmentList: [Segment] = []
+    public func segmentCallsIn<T: SegmentBatchCodable>(from log: [ProxyLogElement], completion: @escaping ([Segment<T>]) -> Void) {
+        var segmentList: [Segment<T>] = []
         for element in log {
             if element.host == "api.segment.io" {
                 let segmentString = element.request?.body?.text
                 let segmentData = segmentString!.data(using: .utf8)!
-                let segment = try! self.decoder.decode(Segment.self, from: segmentData)
+                let segment = try! self.decoder.decode(Segment<T>.self, from: segmentData)
                 segmentList.append(segment)
             }
         }
         completion(segmentList)
     }
     
-    public func matchingSegmentBatchesIn(completion: @escaping ([BatchElement]) -> Void, from segmentList: [Segment], expectedCallType: String, expectedPageType: String) {
-        var expectedBatchElements: [BatchElement] = []
+    public func matchingSegmentBatchesIn<T: SegmentBatchCodable>(completion: @escaping ([T]) -> Void, from segmentList: [Segment<T>], expectedCallType: String, expectedPageName: String) {
+        var expectedBatchElements: [T] = []
         for segmentElement in segmentList {
             let batch = segmentElement.batch
             for batchElement in batch ?? [] {
-                if batchElement.type == expectedCallType && batchElement.properties?.pageType == expectedPageType {
+                if batchElement.type == expectedCallType && batchElement.name == expectedPageName {
                     expectedBatchElements.append(batchElement)
                 }
             }

--- a/Classes/SegmentService.swift
+++ b/Classes/SegmentService.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public typealias SegmentResult<T: SegmentBatchCodable> = Result<[T], Error>
-public typealias DefaultSegmentResult = SegmentResult<BatchElement>
+public typealias DefaultSegmentResult = SegmentResult<DefaultBatchElement>
 
 public enum SegmentError: Error {
     case noElementsFound
@@ -23,7 +23,7 @@ public class SegmentService {
     }
     
     // Waits in 5 second intervals. Default numberOfTries waits 90 seconds.
-    public func checkForSegmentCalls<T: SegmentBatchCodable>(expectedCallType: String, expectedPageName: String, completion: @escaping (Result<[T], Error>) -> ()) {
+    public func checkForSegmentCalls<T: SegmentBatchCodable>(expectedCallType: String, expectedCallName: String, completion: @escaping (Result<[T], Error>) -> ()) {
         let client = CharlesClient()
         let service = SegmentService()
         client.exportData(completion: { (data) in
@@ -40,7 +40,7 @@ public class SegmentService {
                     },
                         from: segmentList,
                         expectedCallType: expectedCallType,
-                        expectedPageName: expectedPageName
+                        expectedCallName: expectedCallName
                     )
                 })
             })
@@ -65,12 +65,12 @@ public class SegmentService {
         completion(segmentList)
     }
     
-    public func matchingSegmentBatchesIn<T: SegmentBatchCodable>(completion: @escaping ([T]) -> Void, from segmentList: [Segment<T>], expectedCallType: String, expectedPageName: String) {
+    public func matchingSegmentBatchesIn<T: SegmentBatchCodable>(completion: @escaping ([T]) -> Void, from segmentList: [Segment<T>], expectedCallType: String, expectedCallName: String) {
         var expectedBatchElements: [T] = []
         for segmentElement in segmentList {
             let batch = segmentElement.batch
             for batchElement in batch ?? [] {
-                if batchElement.type == expectedCallType && batchElement.name == expectedPageName {
+                if batchElement.type == expectedCallType && batchElement.name == expectedCallName {
                     expectedBatchElements.append(batchElement)
                 }
             }

--- a/Classes/ValidatorExtension.swift
+++ b/Classes/ValidatorExtension.swift
@@ -3,7 +3,7 @@ import XCTest
 
 public extension XCTestCase {
     typealias ValidationFunction<T: SegmentBatchCodable> = (T) -> ()
-    func segmentValidator<T: SegmentBatchCodable>(result: Result<[T], Error>, expectation: XCTestExpectation, maxRetries: Int, currentRetries: Int = 0, expectedCallType: String = "screen", expectedPageName: String, validator: @escaping ValidationFunction<T>) {
+    func segmentValidator<T: SegmentBatchCodable>(result: Result<[T], Error>, expectation: XCTestExpectation, maxRetries: Int, currentRetries: Int = 0, expectedCallType: String = "screen", expectedCallName: String, validator: @escaping ValidationFunction<T>) {
         switch result {
         case .success(let finalResult):
             XCTAssertFalse(finalResult.isEmpty)
@@ -16,9 +16,9 @@ public extension XCTestCase {
                 expectation.fulfill()
                 return
             }
-            SegmentService().checkForSegmentCalls(expectedCallType: expectedCallType, expectedPageName: expectedPageName) { [weak self]
+            SegmentService().checkForSegmentCalls(expectedCallType: expectedCallType, expectedCallName: expectedCallName) { [weak self]
                 (result) in
-                self?.segmentValidator(result: result, expectation: expectation, maxRetries: maxRetries, currentRetries: currentRetries + 1, expectedCallType: expectedCallType, expectedPageName: expectedPageName, validator: validator)
+                self?.segmentValidator(result: result, expectation: expectation, maxRetries: maxRetries, currentRetries: currentRetries + 1, expectedCallType: expectedCallType, expectedCallName: expectedCallName, validator: validator)
             }
         }
     }

--- a/Classes/ValidatorExtension.swift
+++ b/Classes/ValidatorExtension.swift
@@ -2,8 +2,8 @@ import Foundation
 import XCTest
 
 public extension XCTestCase {
-    typealias ValidationFunction = (BatchElement) -> ()
-    func segmentValidator(result: Result<[BatchElement], Error>, expectation: XCTestExpectation, maxRetries: Int, currentRetries: Int = 0, expectedCallType: String = "screen", expectedPageType: String, validator: @escaping ValidationFunction) {
+    typealias ValidationFunction<T: SegmentBatchCodable> = (T) -> ()
+    func segmentValidator<T: SegmentBatchCodable>(result: Result<[T], Error>, expectation: XCTestExpectation, maxRetries: Int, currentRetries: Int = 0, expectedCallType: String = "screen", expectedPageName: String, validator: @escaping ValidationFunction<T>) {
         switch result {
         case .success(let finalResult):
             XCTAssertFalse(finalResult.isEmpty)
@@ -16,9 +16,9 @@ public extension XCTestCase {
                 expectation.fulfill()
                 return
             }
-            SegmentService().checkForSegmentCalls(expectedCallType: expectedCallType, expectedPageType: expectedPageType) { [weak self]
+            SegmentService().checkForSegmentCalls(expectedCallType: expectedCallType, expectedPageName: expectedPageName) { [weak self]
                 (result) in
-                self?.segmentValidator(result: result, expectation: expectation, maxRetries: maxRetries, currentRetries: currentRetries + 1, expectedCallType: expectedCallType, expectedPageType: expectedPageType, validator: validator)
+                self?.segmentValidator(result: result, expectation: expectation, maxRetries: maxRetries, currentRetries: currentRetries + 1, expectedCallType: expectedCallType, expectedPageName: expectedPageName, validator: validator)
             }
         }
     }

--- a/ios-segment-tool.xcodeproj/project.pbxproj
+++ b/ios-segment-tool.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AC02DB772444D9ED00151532 /* ProxyLogRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02DB6C2444D9ED00151532 /* ProxyLogRequest.swift */; };
 		AC02DB782444D9ED00151532 /* ValidatorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02DB6D2444D9ED00151532 /* ValidatorExtension.swift */; };
 		AC02DB792444D9ED00151532 /* ProxyLogRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02DB6E2444D9ED00151532 /* ProxyLogRequestBody.swift */; };
+		B155D789245A09ED0007ABA3 /* SegmentBatchCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B155D788245A09ED0007ABA3 /* SegmentBatchCodable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -50,6 +51,7 @@
 		AC02DB6C2444D9ED00151532 /* ProxyLogRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProxyLogRequest.swift; sourceTree = "<group>"; };
 		AC02DB6D2444D9ED00151532 /* ValidatorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatorExtension.swift; sourceTree = "<group>"; };
 		AC02DB6E2444D9ED00151532 /* ProxyLogRequestBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProxyLogRequestBody.swift; sourceTree = "<group>"; };
+		B155D788245A09ED0007ABA3 /* SegmentBatchCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentBatchCodable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +147,7 @@
 			children = (
 				AC02DB642444D9ED00151532 /* ProxyLogElement.swift */,
 				AC02DB652444D9ED00151532 /* SegmentService.swift */,
+				B155D788245A09ED0007ABA3 /* SegmentBatchCodable.swift */,
 				AC02DB662444D9ED00151532 /* BatchElement.swift */,
 				AC02DB672444D9ED00151532 /* CharlesClient.swift */,
 				AC02DB682444D9ED00151532 /* BatchApp.swift */,
@@ -218,6 +221,7 @@
 				AC02DB712444D9ED00151532 /* BatchElement.swift in Sources */,
 				AC02DB742444D9ED00151532 /* Segment.swift in Sources */,
 				AC02DB6F2444D9ED00151532 /* ProxyLogElement.swift in Sources */,
+				B155D789245A09ED0007ABA3 /* SegmentBatchCodable.swift in Sources */,
 				AC02DB752444D9ED00151532 /* BatchProperties.swift in Sources */,
 				AC02DB702444D9ED00151532 /* SegmentService.swift in Sources */,
 				AC02DB762444D9ED00151532 /* BatchTraits.swift in Sources */,


### PR DESCRIPTION
...for the purpose of decoding project specific segment properties

use example:

![Screen Shot 2020-04-30 at 11 33 26 AM](https://user-images.githubusercontent.com/60358275/80729580-717eef00-8ad6-11ea-814e-4a33eb88522b.png)

also, these are obviously breaking changes so that may affect your versioning