### PR TITLE
support track and identify event types

### DIFF
--- a/Classes/BatchElement.swift
+++ b/Classes/BatchElement.swift
@@ -14,4 +14,5 @@ public struct DefaultBatchElement: SegmentBatchCodable {
     public var properties: DefaultBatchProperties?
     public var type: String?
     public var name: String?
+    public var event: String?
 }

--- a/Classes/SegmentBatchCodable.swift
+++ b/Classes/SegmentBatchCodable.swift
@@ -10,4 +10,5 @@ import Foundation
 public protocol SegmentBatchCodable: Codable {
     var type: String? { get }
     var name: String? { get }
+    var event: String? { get }
 }

--- a/Classes/SegmentCallType.swift
+++ b/Classes/SegmentCallType.swift
@@ -1,0 +1,14 @@
+//
+//  SegmentCallType.swift
+//  ios-segment-tool
+//
+//  Created by Samuel Lambert on 5/1/20.
+//
+
+import Foundation
+
+public enum SegmentCallType: String {
+    case screen
+    case track
+    case identify
+}

--- a/Classes/ValidatorExtension.swift
+++ b/Classes/ValidatorExtension.swift
@@ -3,7 +3,20 @@ import XCTest
 
 public extension XCTestCase {
     typealias ValidationFunction<T: SegmentBatchCodable> = (T) -> ()
-    func segmentValidator<T: SegmentBatchCodable>(result: Result<[T], Error>, expectation: XCTestExpectation, maxRetries: Int, currentRetries: Int = 0, expectedCallType: String = "screen", expectedCallName: String, validator: @escaping ValidationFunction<T>) {
+
+    /**
+     Repeatedly checks for event calls based on call type and identifier.
+     Waits in 5 second intervals. Default numberOfTries waits 90 seconds.
+
+     - Parameters:
+        - result: Result from completion handler of initial `checkForSegmentCalls`
+        - expectation: Expectation to be fulfilled once result of the check is completed.
+        - maxRetries: Maximum number of times to retry checking for expected call.
+        - expectedCallType: Type of the call, either screen, track, or identify.
+        - expectedIdentifier: This will match against the "name" of screen calls or the "event" of track calls. **Ignored in identify calls.**
+        - validator: Completion handler to be performed with the collected calls. Should specify a ValidationFunction with a type conforming to `SegmentBatchCodable`.
+     */
+    func segmentValidator<T: SegmentBatchCodable>(result: Result<[T], Error>, expectation: XCTestExpectation, maxRetries: Int, currentRetries: Int = 0, expectedCallType: SegmentCallType = .screen, expectedIdentifier: String?, validator: @escaping ValidationFunction<T>) {
         switch result {
         case .success(let finalResult):
             XCTAssertFalse(finalResult.isEmpty)
@@ -16,9 +29,9 @@ public extension XCTestCase {
                 expectation.fulfill()
                 return
             }
-            SegmentService().checkForSegmentCalls(expectedCallType: expectedCallType, expectedCallName: expectedCallName) { [weak self]
+            SegmentService().checkForSegmentCalls(expectedCallType: expectedCallType, expectedIdentifier: expectedIdentifier) { [weak self]
                 (result) in
-                self?.segmentValidator(result: result, expectation: expectation, maxRetries: maxRetries, currentRetries: currentRetries + 1, expectedCallType: expectedCallType, expectedCallName: expectedCallName, validator: validator)
+                self?.segmentValidator(result: result, expectation: expectation, maxRetries: maxRetries, currentRetries: currentRetries + 1, expectedCallType: expectedCallType, expectedIdentifier: expectedIdentifier, validator: validator)
             }
         }
     }

--- a/ios-segment-tool.xcodeproj/project.pbxproj
+++ b/ios-segment-tool.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AC02DB772444D9ED00151532 /* ProxyLogRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02DB6C2444D9ED00151532 /* ProxyLogRequest.swift */; };
 		AC02DB782444D9ED00151532 /* ValidatorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02DB6D2444D9ED00151532 /* ValidatorExtension.swift */; };
 		AC02DB792444D9ED00151532 /* ProxyLogRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC02DB6E2444D9ED00151532 /* ProxyLogRequestBody.swift */; };
+		B1238AD1245C5EEA00CCD5B2 /* SegmentCallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1238AD0245C5EEA00CCD5B2 /* SegmentCallType.swift */; };
 		B155D789245A09ED0007ABA3 /* SegmentBatchCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B155D788245A09ED0007ABA3 /* SegmentBatchCodable.swift */; };
 /* End PBXBuildFile section */
 
@@ -51,6 +52,7 @@
 		AC02DB6C2444D9ED00151532 /* ProxyLogRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProxyLogRequest.swift; sourceTree = "<group>"; };
 		AC02DB6D2444D9ED00151532 /* ValidatorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatorExtension.swift; sourceTree = "<group>"; };
 		AC02DB6E2444D9ED00151532 /* ProxyLogRequestBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProxyLogRequestBody.swift; sourceTree = "<group>"; };
+		B1238AD0245C5EEA00CCD5B2 /* SegmentCallType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentCallType.swift; sourceTree = "<group>"; };
 		B155D788245A09ED0007ABA3 /* SegmentBatchCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentBatchCodable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -152,6 +154,7 @@
 				AC02DB672444D9ED00151532 /* CharlesClient.swift */,
 				AC02DB682444D9ED00151532 /* BatchApp.swift */,
 				AC02DB692444D9ED00151532 /* Segment.swift */,
+				B1238AD0245C5EEA00CCD5B2 /* SegmentCallType.swift */,
 				AC02DB6A2444D9ED00151532 /* BatchProperties.swift */,
 				AC02DB6B2444D9ED00151532 /* BatchTraits.swift */,
 				AC02DB6C2444D9ED00151532 /* ProxyLogRequest.swift */,
@@ -230,6 +233,7 @@
 				AC02DB792444D9ED00151532 /* ProxyLogRequestBody.swift in Sources */,
 				AC02DB722444D9ED00151532 /* CharlesClient.swift in Sources */,
 				AC02DB732444D9ED00151532 /* BatchApp.swift in Sources */,
+				B1238AD1245C5EEA00CCD5B2 /* SegmentCallType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
added SegmentCallType enum to avoid switching against a string. makes the logic cleaner. these are the only 3 event types afaik

`SegmentBatchCodable` now requires an event property

also added some documention to compensate for the less clear `expectedIdentifier` parameter